### PR TITLE
Vote deals

### DIFF
--- a/app/src/main/java/com/example/smartshopper/common/PlatformHelpers.java
+++ b/app/src/main/java/com/example/smartshopper/common/PlatformHelpers.java
@@ -1,7 +1,6 @@
 package com.example.smartshopper.common;
 
 import android.content.Context;
-import android.util.Log;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
@@ -19,6 +18,7 @@ import com.example.smartshopper.services.RTDBService;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.Query;
+import com.google.firebase.database.Transaction;
 import com.google.firebase.database.ValueEventListener;
 import com.squareup.picasso.Picasso;
 
@@ -111,6 +111,14 @@ public class PlatformHelpers {
 
     }
 
+    public void upVoteDeal(String dealID) {
+        rtdbDatabase.upVoteDeal(dealID);
+    }
+
+    public void downVoteDeal(String dealID) {
+        rtdbDatabase.downVoteDeal(dealID);
+    }
+
     public void getCommentsAndUpdateRv(Deal deal, CommentsAdapter adapter) {
         Query query = rtdbDatabase.getComments(deal);
         query.addListenerForSingleValueEvent(new ValueEventListener() {
@@ -137,7 +145,7 @@ public class PlatformHelpers {
     public void getDealsAndUpdateMainRV(DealAdapter adapter) {
         //TODO case switch queryEnum to get the correct query from FireBase
         Query query = rtdbDatabase.getBestDeals();
-        query.addListenerForSingleValueEvent(new ValueEventListener() {
+        query.addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot snapshot) {
                 List<Deal> deals = new ArrayList<>();
@@ -159,17 +167,15 @@ public class PlatformHelpers {
 
     /**
      * Loads picture using Piccasso Library
-     *
-     * @param context    view you are loading into
+     *  @param context    view you are loading into
      * @param imgUri     string of the URI of the image
      * @param view       ImageView you are trying to load the picture into
      * @param defaultImg default image if there is an error (should be a local asset)
      */
-    public static Picasso loadPicassoImg(Context context, String imgUri, ImageView view, int defaultImg) {
+    public static void loadPicassoImg(Context context, String imgUri, ImageView view, int defaultImg) {
         Picasso picasso = new Picasso.Builder(context).build();
         picasso.load(imgUri)
                 .error(defaultImg) // removed .placeholder just left .error
                 .into(view);
-        return picasso;
     }
 }

--- a/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
+++ b/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
@@ -61,14 +61,22 @@ public class DealAdapter extends RecyclerView.Adapter<DealViewHolder> {
         holder.tv_numDownVotes.setText(deals.get(position).getNumDownVotes().toString());
         holder.tv_numUpvotes.setText(deals.get(position).getNumUpVotes().toString());
 
-        holder.iv_downVote.setOnClickListener(v-> {
+        // Up vote down vote listeners
+        holder.iv_downVote.setOnClickListener(v -> {
+            platformHelpers.downVoteDeal(deals.get(position).getDealID());
+        });
+        holder.iv_upVote.setOnClickListener(v -> {
+            platformHelpers.upVoteDeal(deals.get(position).getDealID());
+        });
+        holder.tv_numDownVotes.setOnClickListener(v -> {
             platformHelpers.downVoteDeal(deals.get(position).getDealID());
         });
 
-        holder.iv_upVote.setOnClickListener(v-> {
+        holder.tv_numUpvotes.setOnClickListener(v -> {
             platformHelpers.upVoteDeal(deals.get(position).getDealID());
         });
 
+        // Entire deal card listener
         holder.itemView.setOnClickListener(v -> {
             if (context != null) {
                 Intent intent = new Intent(context, DealDetailsActivity.class);

--- a/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
+++ b/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
@@ -58,6 +58,16 @@ public class DealAdapter extends RecyclerView.Adapter<DealViewHolder> {
         holder.tv_originalPrice.setText(NumberFormat.getCurrencyInstance().format(deals.get(position).getOriginalPrice()));
         holder.tv_originalPrice.setPaintFlags(Paint.STRIKE_THRU_TEXT_FLAG); // strike-through OG price
         holder.tv_salePrice.setText(NumberFormat.getCurrencyInstance().format(deals.get(position).getSalePrice()));
+        holder.tv_numDownVotes.setText(deals.get(position).getNumDownVotes().toString());
+        holder.tv_numUpvotes.setText(deals.get(position).getNumUpVotes().toString());
+
+        holder.iv_downVote.setOnClickListener(v-> {
+            platformHelpers.downVoteDeal(deals.get(position).getDealID());
+        });
+
+        holder.iv_upVote.setOnClickListener(v-> {
+            platformHelpers.upVoteDeal(deals.get(position).getDealID());
+        });
 
         holder.itemView.setOnClickListener(v -> {
             if (context != null) {

--- a/app/src/main/java/com/example/smartshopper/recyclerViews/DealViewHolder.java
+++ b/app/src/main/java/com/example/smartshopper/recyclerViews/DealViewHolder.java
@@ -18,6 +18,10 @@ public class DealViewHolder extends RecyclerView.ViewHolder {
     public TextView tv_originalPrice;
     public TextView tv_salePrice;
     public TextView tv_store;
+    public TextView tv_numDownVotes;
+    public TextView tv_numUpvotes;
+    public ImageView iv_upVote;
+    public ImageView iv_downVote;
 
     public DealViewHolder(@NonNull View itemView, Context context) {
         super(itemView);
@@ -28,6 +32,10 @@ public class DealViewHolder extends RecyclerView.ViewHolder {
         this.tv_originalPrice = itemView.findViewById(R.id.tv_originalPrice);
         this.tv_salePrice = itemView.findViewById(R.id.tv_salePrice);
         this.tv_store = itemView.findViewById(R.id.tv_store);
+        this.tv_numDownVotes = itemView.findViewById(R.id.tv_numDownVotes);
+        this.tv_numUpvotes = itemView.findViewById(R.id.tv_numUpvotes);
+        this.iv_upVote = itemView.findViewById(R.id.iv_upVote);
+        this.iv_downVote = itemView.findViewById(R.id.iv_downVote);
     }
 }
 

--- a/app/src/main/java/com/example/smartshopper/services/RTDBService.java
+++ b/app/src/main/java/com/example/smartshopper/services/RTDBService.java
@@ -1,19 +1,12 @@
 package com.example.smartshopper.services;
 
-import androidx.annotation.NonNull;
-
 import com.example.smartshopper.common.Constants;
 import com.example.smartshopper.models.Comment;
 import com.example.smartshopper.models.Deal;
 import com.example.smartshopper.models.User;
-import com.example.smartshopper.responseInterfaces.BoolInterface;
-import com.example.smartshopper.responseInterfaces.DealInterface;
-import com.example.smartshopper.responseInterfaces.ObjectInterface;
-import com.google.firebase.database.DataSnapshot;
-import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.Query;
-import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.database.ServerValue;
 
 public class RTDBService {
     FirebaseDatabase database = FirebaseDatabase.getInstance();
@@ -101,38 +94,19 @@ public class RTDBService {
         database.getReference().child(Constants.DEALS).child(dealID).child(Constants.COMMENTS).push().setValue(comment);
     }
 
-
-    // Use this to determine whether item exists (bool) for particular query
-    public void getStatusResponseFromQuery(Query query, BoolInterface boolInterface) {
-        query.addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot snapshot) {
-                boolInterface.onCallback(snapshot.exists());
-            }
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError error) {
-            }
-        });
+    public void upVoteDeal(String dealId) {
+        database.getReference()
+                .child(Constants.DEALS)
+                .child(dealId)
+                .child(Constants.UPVOTES)
+                .setValue(ServerValue.increment(1));
     }
 
-    // Use this to get a single response (object) from a query, may contain children
-    public void getDataResponseFromQuery(Query query, ObjectInterface objectInterface) {
-        query.addListenerForSingleValueEvent(new ValueEventListener() {
-            @Override
-            public void onDataChange(@NonNull DataSnapshot snapshot) {
-                if (snapshot.exists()) {
-                    objectInterface.onCallback(snapshot.getValue());
-                } else {
-                    objectInterface.onCallback(null);
-                }
-            }
-
-
-            @Override
-            public void onCancelled(@NonNull DatabaseError error) {
-            }
-        });
+    public void downVoteDeal(String dealId) {
+        database.getReference()
+                .child(Constants.DEALS)
+                .child(dealId)
+                .child(Constants.DOWNVOTES)
+                .setValue(ServerValue.increment(1));
     }
-
 }


### PR DESCRIPTION
first draft of upvote and downvotes
- listeners are on the imageView (thumbs up and down) and textView (numUpVotes and numDownVotes)
    - this means if the user clicks in white space between, it will be part of the Entire Deal card listener and go to dealDeatilsActivity
    - maybe we can wrap the imageView and textView in their own Relative Layout and just put a listener on the Relative Layout??
- upVotes and downVotes trigger recyclerView refresh therefore a reload flicker happens
    - can possibly change to singleEventListener and upon each click just increment on the front end while sending an update to the backend
- do we want to limit dealUpVotes to once per user? if so we may need to keep a record of who upVoted on the deal.