### PR TITLE
Missing Null Checks for NavigationMenu

### DIFF
--- a/app/src/main/java/com/example/smartshopper/MainActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MainActivity.java
@@ -28,6 +28,7 @@ import com.example.smartshopper.common.PlatformHelpers;
 import com.example.smartshopper.recyclerViews.DealAdapter;
 import com.example.smartshopper.utilities.LocalStorage;
 import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -36,11 +37,11 @@ import java.util.Arrays;
 import java.util.Map;
 
 public class MainActivity extends MenuActivity {
-    RecyclerView rv_dealsRecyclerView;
-    View loadingAnimation;
-    PlatformHelpers platformHelpers;
-    DealAdapter adapter;
-    LocalStorage localStorage;
+  RecyclerView rv_dealsRecyclerView;
+  View loadingAnimation;
+  PlatformHelpers platformHelpers;
+  DealAdapter adapter;
+  LocalStorage localStorage;
   FusedLocationProviderClient fusedLocationProviderClient;
   LocationManager locationManager;
   private final static int FINE_REQUEST_CODE = 200;

--- a/app/src/main/java/com/example/smartshopper/MenuActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MenuActivity.java
@@ -28,10 +28,10 @@ public class MenuActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         localStorage = new LocalStorage(this);
         loginMenuItem = findViewById(R.id.nav_logout);
-        if (localStorage != null && localStorage.userIsLoggedIn()) {
+        if (loginMenuItem != null && localStorage != null && localStorage.userIsLoggedIn()) {
             loginMenuItem.setTitle("Sign Out");
         }
-        else if (localStorage != null && !localStorage.userIsLoggedIn()) {
+        else if (loginMenuItem != null && localStorage != null && !localStorage.userIsLoggedIn()) {
             loginMenuItem.setTitle("Sign In");
         }
         // https://www.geeksforgeeks.org/navigation-drawer-in-android/
@@ -66,7 +66,9 @@ public class MenuActivity extends AppCompatActivity {
             startActivity(loginIntent);
         }
         else {
-            loginMenuItem.setTitle("Sign In");
+            if (loginMenuItem != null) {
+                loginMenuItem.setTitle("Sign In");
+            }
             localStorage.signOut();
         }
     }


### PR DESCRIPTION
App was throwing errors on some builds when the text for the Sign In/Sign Out button hadn't been inflated yet but setText was being called on it.