### PR TITLE
Bugfix/Dialog for Location Permissions/Permissions Listeners

### DIFF
--- a/app/src/main/java/com/example/smartshopper/MainActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MainActivity.java
@@ -155,9 +155,6 @@ public class MainActivity extends MenuActivity {
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_DENIED) {
           platformHelpers.getDealsAndUpdateMainRV(adapter, null, null, loadingAnimation);
         }
-        else if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-          getLocationAndUpdateRV();
-        }
         else if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
           askFinePermission();
         }
@@ -168,9 +165,6 @@ public class MainActivity extends MenuActivity {
       case FINE_REQUEST_CODE:
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_DENIED) {
             platformHelpers.getDealsAndUpdateMainRV(adapter, null, null, loadingAnimation);
-        }
-        else if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-          getLocationAndUpdateRV();
         }
         else if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
           askCoarsePermission();
@@ -183,22 +177,13 @@ public class MainActivity extends MenuActivity {
   }
 
   public void getLocationAndUpdateRV() {
-    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_DENIED || ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED ) {
-      currentLocation = null;
-      Toast.makeText(getApplicationContext(), "Please allow location access to engage users locally.", Toast.LENGTH_LONG).show();
+    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+      askFinePermission();
     }
-    else if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED || ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED ) {
-      if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_DENIED || ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_DENIED) {
-        currentLocation = null;
-      }
-      else if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-        askCoarsePermission();
-      }
-      if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-        askFinePermission();
-      }
+    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+      askFinePermission();
     }
-    else {
+    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_DENIED) {
       currentLocation = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
     }
       platformHelpers.getDealsAndUpdateMainRV(adapter, null, currentLocation, loadingAnimation);


### PR DESCRIPTION
- The permissions dialog wasn't displaying on load. 
- The user should also still be able to browse without approving permissions