### PR TITLE
Activity cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         tools:targetApi="31">
         <activity
             android:name=".CreateDealActivity"
-            android:exported="false">
+            android:exported="false"
+            android:configChanges="orientation|screenSize">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
@@ -36,17 +37,20 @@
 
         <activity
             android:name=".SavedDealsActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:configChanges="orientation|screenSize" />
         <activity
             android:name=".DealDetailsActivity"
-            android:exported="false">
+            android:exported="false"
+            android:configChanges="orientation|screenSize">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
         <activity
             android:name=".ProfileActivity"
-            android:exported="false">
+            android:exported="false"
+            android:configChanges="orientation|screenSize">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
@@ -65,7 +69,8 @@
             android:parentActivityName=".LoginActivity" />
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/smartshopper/CreateAccountActivity.java
+++ b/app/src/main/java/com/example/smartshopper/CreateAccountActivity.java
@@ -26,6 +26,7 @@ public class CreateAccountActivity extends AppCompatActivity {
   LocalStorage localStorage;
   NavigationMenuItemView signinButton;
   CheckBox agreeToTerms;
+  final int FINISH_CODE = 10101;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -70,6 +71,8 @@ public class CreateAccountActivity extends AppCompatActivity {
           signIn(userInterface);
           Intent mainActivityIntent = new Intent(context, MainActivity.class);
           context.startActivity(mainActivityIntent);
+          setResult(FINISH_CODE);
+          this.finish();
         }
         else {
           Toast.makeText(context, "Username or email taken. Please try again.", Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/example/smartshopper/CreateDealActivity.java
+++ b/app/src/main/java/com/example/smartshopper/CreateDealActivity.java
@@ -254,6 +254,7 @@ public class CreateDealActivity extends MenuActivity {
                         // Go to detailed view of the deal
                         intent.putExtra("dealItem", deal);
                         startActivity(intent);
+                        CreateDealActivity.this.finish();
                     }
                 }
             }

--- a/app/src/main/java/com/example/smartshopper/LoginActivity.java
+++ b/app/src/main/java/com/example/smartshopper/LoginActivity.java
@@ -15,6 +15,7 @@ public class LoginActivity extends MenuActivity {
   EditText emailAddressET;
   EditText passwordET;
   LocalStorage localStorage;
+  final int FINISH_CODE = 10101;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -42,6 +43,7 @@ public class LoginActivity extends MenuActivity {
         Toast.makeText(getApplicationContext(), "Welcome back "+ userInterface.getUsername() + "!", Toast.LENGTH_LONG).show();
         Intent mainActivityIntent = new Intent(this, MainActivity.class);
         this.startActivity(mainActivityIntent);
+        this.finish();
       } else {
         Toast.makeText(this, "Invalid Credentials", Toast.LENGTH_SHORT).show();
       }
@@ -55,7 +57,15 @@ public class LoginActivity extends MenuActivity {
 
   public void sendToCreateAccountActivity(View view) {
     Intent createAccountIntent = new Intent(this, CreateAccountActivity.class);
-    startActivity(createAccountIntent);
+    startActivityForResult(createAccountIntent, FINISH_CODE);
+  }
+
+  @Override
+  public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    super.onActivityResult(requestCode, resultCode, intent);
+    if (resultCode == FINISH_CODE) {
+      this.finish();
+    }
   }
 
 }

--- a/app/src/main/java/com/example/smartshopper/MainActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MainActivity.java
@@ -43,13 +43,6 @@ public class MainActivity extends MenuActivity {
   MaterialButtonToggleGroup buttonGroup;
   ImageView sortIcon;
 
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    checkLocationPermissionAndGetLocation();
-  }
-
   @SuppressLint("ResourceAsColor")
   @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -103,6 +96,15 @@ public class MainActivity extends MenuActivity {
       }
     });
   }
+
+    @Override
+    protected void onRestart() {
+      super.onRestart();
+      if (localStorage.userIsLoggedIn()) {
+          platformHelpers.createNotifChannel();
+      }
+      checkLocationPermissionAndGetLocation();
+    }
 
     private void setSearchListener() {
         SearchView searchView = findViewById(R.id.sv_searchBar);

--- a/app/src/main/java/com/example/smartshopper/MainActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.location.Location;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -36,6 +37,8 @@ public class MainActivity extends MenuActivity {
   LocalStorage localStorage;
   FusedLocationProviderClient fusedLocationProviderClient;
   private final static int COARSE_REQUEST_CODE = 100;
+  private final int SORT_BY_DISTANCE = 0;
+  private final int SORT_BY_POPULARITY = 1;
   Context context = this;
   Location currentLocation;
   MaterialButton toggleSortDistance;
@@ -83,17 +86,34 @@ public class MainActivity extends MenuActivity {
 
     toggleSortPopularity.addOnCheckedChangeListener((button, isChecked) -> {
       if (button.getId() == R.id.toggle_sortByPopularity) {
-        toggleSortPopularity.setBackgroundColor(Color.parseColor("#B3D1B9"));
-        toggleSortDistance.setBackgroundColor(Color.parseColor("#BEBEBE"));
-        sortDealsBy(button);
+        if (isChecked) {
+            localStorage.setSortPreference(SORT_BY_POPULARITY);
+            toggleSortDistance.setChecked(false);
+            toggleSortPopularity.setBackgroundColor(Color.parseColor("#B3D1B9"));
+            toggleSortDistance.setBackgroundColor(Color.parseColor("#BEBEBE"));
+            sortDealsBy(button);
+        }
       }
     });
+
     toggleSortDistance.addOnCheckedChangeListener((button, isChecked) -> {
       if (button.getId() == R.id.toggle_sortByDistance) {
-        toggleSortPopularity.setBackgroundColor(Color.parseColor("#BEBEBE"));
-        toggleSortDistance.setBackgroundColor(Color.parseColor("#B3D1B9"));
-        sortDealsBy(button);
+          if (isChecked) {
+              localStorage.setSortPreference(SORT_BY_DISTANCE);
+              toggleSortPopularity.setChecked(false);
+              toggleSortPopularity.setBackgroundColor(Color.parseColor("#BEBEBE"));
+              toggleSortDistance.setBackgroundColor(Color.parseColor("#B3D1B9"));
+              sortDealsBy(button);
+          }
       }
+    });
+
+    toggleSortDistance.setOnClickListener(v -> {
+        if (currentLocation == null) {
+            Toast.makeText(this, "Unable to fetch your location. Please check your location settings.", Toast.LENGTH_SHORT).show();
+            toggleSortDistance.setChecked(false);
+            toggleSortPopularity.setChecked(true);
+        }
     });
   }
 
@@ -157,6 +177,8 @@ public class MainActivity extends MenuActivity {
                 platformHelpers.getCurrentLocation(location -> {
                     if (location != null) {
                         currentLocation = location;
+                        toggleSortPopularity.setChecked(false);
+                        toggleSortDistance.setChecked(true);
                         platformHelpers.getDealsAndUpdateMainRV(adapter, null, currentLocation, loadingAnimation);
                     }
                 });
@@ -175,7 +197,18 @@ public class MainActivity extends MenuActivity {
             platformHelpers.getCurrentLocation(location -> {
                 if (location != null) {
                     currentLocation = location;
-                    platformHelpers.getDealsAndUpdateMainRV(adapter, null, currentLocation, loadingAnimation);
+                    if (localStorage.getSortPreference() == SORT_BY_DISTANCE) {
+                        toggleSortPopularity.setChecked(false);
+                        toggleSortDistance.setChecked(true);
+                    } else {
+                        // if user prefers to sort by popularity
+                        toggleSortDistance.setChecked(false);
+                        toggleSortPopularity.setChecked(true);
+                    }
+                } else {
+                    // if location was null
+                    toggleSortDistance.setChecked(false);
+                    toggleSortPopularity.setChecked(true);
                 }
             });
         }

--- a/app/src/main/java/com/example/smartshopper/MenuActivity.java
+++ b/app/src/main/java/com/example/smartshopper/MenuActivity.java
@@ -1,15 +1,19 @@
 package com.example.smartshopper;
 
 import android.annotation.SuppressLint;
+import android.app.AlertDialog;
 import android.content.Intent;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.drawerlayout.widget.DrawerLayout;
+
 import com.example.smartshopper.utilities.LocalStorage;
 import com.example.smartshopper.utilities.NavigationDrawer;
 import com.google.android.material.internal.NavigationMenuItemView;
@@ -21,6 +25,7 @@ public class MenuActivity extends AppCompatActivity {
     ActionBarDrawerToggle actionBarDrawerToggle;
     NavigationDrawer navigationDrawer;
     LocalStorage localStorage;
+    NavigationView navigationView;
     NavigationMenuItemView loginMenuItem;
 
     @SuppressLint("RestrictedApi")
@@ -41,7 +46,15 @@ public class MenuActivity extends AppCompatActivity {
         navigationDrawer = new NavigationDrawer(this, drawerLayout, actionBarDrawerToggle);
         // to make the Navigation drawer icon always appear on the action bar
         Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        navigationView = findViewById(R.id.navigation_view);
         setNavigationViewListener();
+        View navHeader = navigationView.getHeaderView(0);
+        if (localStorage.userIsLoggedIn()) {
+            TextView navText = navHeader.findViewById(R.id.tv_greeting);
+            navText.setText("Hi " + localStorage.getCurrentUser() + "!");
+        } else {
+            navHeader.setVisibility(View.GONE);
+        }
         MenuInflater menuInflater = getMenuInflater();
         menuInflater.inflate(R.menu.navigation_menu, menu);
         return true;
@@ -55,7 +68,6 @@ public class MenuActivity extends AppCompatActivity {
         return super.onOptionsItemSelected(item);
     }
     private void setNavigationViewListener() {
-        NavigationView navigationView = findViewById(R.id.navigation_view);
         navigationView.setNavigationItemSelectedListener(navigationDrawer);
     }
 
@@ -66,10 +78,24 @@ public class MenuActivity extends AppCompatActivity {
             startActivity(loginIntent);
         }
         else {
-            if (loginMenuItem != null) {
-                loginMenuItem.setTitle("Sign In");
-            }
-            localStorage.signOut();
+            AlertDialog signOutAlert = new AlertDialog.Builder(this)
+                    .setMessage("Are you sure you want to sign out?")
+                    .setPositiveButton("Yes", (dialog, which) -> {
+                        dialog.dismiss();
+                        if (loginMenuItem != null) {
+                            loginMenuItem.setTitle("Sign In");
+                        }
+                        localStorage.signOut();
+                        Intent logoutIntent = new Intent(getApplicationContext(), MainActivity.class);
+                        logoutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                        logoutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                        logoutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        startActivity(logoutIntent);
+                    })
+                    .setNegativeButton("No", (dialog, which) -> {
+                        dialog.dismiss();
+                    })
+                    .show();
         }
     }
 }

--- a/app/src/main/java/com/example/smartshopper/ProfileActivity.java
+++ b/app/src/main/java/com/example/smartshopper/ProfileActivity.java
@@ -37,7 +37,5 @@ public class ProfileActivity extends MenuActivity {
         tv_username.setText(localStorage.getCurrentUser());
 
         platformHelpers.getActivities(localStorage.getCurrentUser(), adapter);
-
-
     }
 }

--- a/app/src/main/java/com/example/smartshopper/SavedDealsActivity.java
+++ b/app/src/main/java/com/example/smartshopper/SavedDealsActivity.java
@@ -33,4 +33,10 @@ public class SavedDealsActivity extends MenuActivity {
         rv_savedDeals.setAdapter(adapter);
         platformHelpers.getSavedDealsAndUpdateRV(adapter, tv_noSavedDeals, loadingAnimation);
     }
+
+    @Override
+    protected void onRestart() {
+        super.onRestart();
+        platformHelpers.getSavedDealsAndUpdateRV(adapter, tv_noSavedDeals, loadingAnimation);
+    }
 }

--- a/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
+++ b/app/src/main/java/com/example/smartshopper/recyclerViews/DealAdapter.java
@@ -99,12 +99,22 @@ public class DealAdapter extends RecyclerView.Adapter<DealViewHolder> {
 
         // Up vote down vote listeners
         holder.frame_downVote.setOnClickListener(v -> {
-            platformHelpers.downVoteDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), platformHelpers.getCurrentUser());
+            platformHelpers.checkIfUserUpVotedDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), isUpvoted -> {
+                // if user did not upvote, they can downvote
+                if (!isUpvoted) {
+                    platformHelpers.downVoteDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), platformHelpers.getCurrentUser());
+                }
+            });
         });
 
         holder.frame_upVote.setOnClickListener(v -> {
-            platformHelpers.upVoteDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), platformHelpers.getCurrentUser());
+            platformHelpers.checkIfUserDownVotedDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), isDownvoted -> {
+                // if user did not downvote, they can upvote
+                if (!isDownvoted) {
+                    platformHelpers.upVoteDeal(deals.get(position).getDealID(), platformHelpers.getCurrentUserID(), platformHelpers.getCurrentUser());
+                }
             });
+        });
 
         // Entire deal card listener
         holder.itemView.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/smartshopper/utilities/LocalStorage.java
+++ b/app/src/main/java/com/example/smartshopper/utilities/LocalStorage.java
@@ -2,10 +2,14 @@ package com.example.smartshopper.utilities;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
+
 import com.example.smartshopper.models.User;
 
 public class LocalStorage {
   private Context context;
+  private final int DISTANCE_CODE = 0;
+  private final int POPULARITY_CODE = 1;
 
   public Boolean userIsLoggedIn() {
     return !context.getSharedPreferences("UserInfo", 0).getString("username", "").equals("");
@@ -23,6 +27,10 @@ public class LocalStorage {
     return context.getSharedPreferences("UserInfo", 0).getString("userEmail", "");
   }
 
+  public int getSortPreference() {
+    return context.getSharedPreferences("UserInfo", 0).getInt("sortPreference", DISTANCE_CODE);
+  }
+
   public LocalStorage(Context context) {
     SharedPreferences settings = context.getSharedPreferences("UserInfo", 0);
     this.context = context;
@@ -36,10 +44,22 @@ public class LocalStorage {
     editor.putString("userID", user.getUserID());
     editor.commit();
   }
+
   public void signOut() {
     SharedPreferences settings = context.getSharedPreferences("UserInfo", 0);
     SharedPreferences.Editor editor = settings.edit();
     editor.clear();
     editor.commit();
+  }
+
+  public void setSortPreference(int code) {
+    if (code != DISTANCE_CODE && code != POPULARITY_CODE) {
+      Log.d("SORTPREFERENCE", "Code: " + code + " is not a valid sort preference code.");
+    } else {
+      SharedPreferences settings = context.getSharedPreferences("UserInfo", 0);
+      SharedPreferences.Editor editor = settings.edit();
+      editor.putInt("sortPreference", code);
+      editor.commit();
+    }
   }
 }

--- a/app/src/main/res/layout/activity_create_deal.xml
+++ b/app/src/main/res/layout/activity_create_deal.xml
@@ -244,6 +244,7 @@
         android:layout_width="200dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:menu="@menu/navigation_menu" />
+        app:menu="@menu/navigation_menu"
+        app:headerLayout="@layout/navigation_header" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_deal_details.xml
+++ b/app/src/main/res/layout/activity_deal_details.xml
@@ -169,5 +169,6 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:layout_gravity="start"
-    app:menu="@menu/navigation_menu" />
+    app:menu="@menu/navigation_menu"
+      app:headerLayout="@layout/navigation_header" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -143,6 +143,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:menu="@menu/navigation_menu" />
+        app:menu="@menu/navigation_menu"
+        app:headerLayout="@layout/navigation_header" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -76,6 +76,7 @@
         android:layout_width="200dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:menu="@menu/navigation_menu" />
+        app:menu="@menu/navigation_menu"
+        app:headerLayout="@layout/navigation_header" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -172,5 +172,6 @@
         android:layout_width="200dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:menu="@menu/navigation_menu" />
+        app:menu="@menu/navigation_menu"
+        app:headerLayout="@layout/navigation_header" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_saved_deals.xml
+++ b/app/src/main/res/layout/activity_saved_deals.xml
@@ -54,6 +54,7 @@
         android:layout_width="200dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        app:menu="@menu/navigation_menu" />
+        app:menu="@menu/navigation_menu"
+        app:headerLayout="@layout/navigation_header" />
 </androidx.drawerlayout.widget.DrawerLayout>
 

--- a/app/src/main/res/layout/navigation_header.xml
+++ b/app/src/main/res/layout/navigation_header.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tv_greeting"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/car_ui_list_item_text_start_margin"
+    android:layout_marginTop="15dp"
+    android:textSize="20dp"
+    android:textStyle="bold"
+    android:textColor="@color/black">
+</TextView>


### PR DESCRIPTION
-Added a dialog window on sign out
-Added a greeting in the nav bar if signed in
-Finished activities (login, create an account, create a deal) so they don't appear again when you press the back button
-When signing out, the user is directed back to the `MainActivity` and the entire app back stack clears. Let me know if you don't want this happening
-Moved `checkLocationPermissionAndGetLocation()` from `onResume()` to `onRestart()`
-Added a message if location services are disabled on the device, and therefore the current location cannot be found
-Remembers a user's sort by distance/popularity preference
-Users can no longer upvote _and_ downvote on the same deal